### PR TITLE
[editor] Support several different goals and attributes with the same name

### DIFF
--- a/django_prosoul/prosoul/forms_editor.py
+++ b/django_prosoul/prosoul/forms_editor.py
@@ -218,8 +218,8 @@ class MetricForm(ProsoulEditorForm):
         if self.state and self.state.attributes:
             attribute_orm = Attribute.objects.get(id=self.state.attributes[0])
             kwargs['initial'].update({
-                'attributes': attribute_orm.name,
-                'old_attribute': attribute_orm.name
+                'attributes': attribute_orm.id,
+                'old_attribute_id': attribute_orm.id
             })
 
         if self.metric_id:
@@ -247,8 +247,9 @@ class MetricForm(ProsoulEditorForm):
 
         choices = ()
 
-        for ds in data_editor.AttributesData(state=None).fetch():
-            choices += ((ds.name, ds.name),)
+        # Show only the attributes for this quality model
+        for attr in data_editor.AttributesData(state=self.state).fetch():
+            choices += ((attr.id, attr.name),)
 
         empty_choice = [('', '')]
         choices = empty_choice + sorted(choices, key=lambda x: x[1])
@@ -268,5 +269,5 @@ class MetricForm(ProsoulEditorForm):
         self.fields['metrics_data'] = forms.ChoiceField(label='Metrics Data', required=False,
                                                         widget=self.widget, choices=choices)
 
-        self.fields['old_attribute'] = forms.CharField(label='old_attribute', max_length=100, required=False)
-        self.fields['old_attribute'].widget = forms.HiddenInput(attrs={'class': 'form-control', 'readonly': 'True'})
+        self.fields['old_attribute_id'] = forms.CharField(label='old_attribute', max_length=100, required=False)
+        self.fields['old_attribute_id'].widget = forms.HiddenInput(attrs={'class': 'form-control', 'readonly': 'True'})

--- a/django_prosoul/prosoul/models.py
+++ b/django_prosoul/prosoul/models.py
@@ -56,7 +56,7 @@ class Factoid(ProsoulModel):
 
 
 class Attribute(ProsoulModel):
-    name = models.CharField(max_length=200, unique=True)
+    name = models.CharField(max_length=200, unique=False)
     # Relations
     metrics = models.ManyToManyField(Metric, blank=True)
     factoids = models.ManyToManyField(Factoid, blank=True)
@@ -67,7 +67,7 @@ class Attribute(ProsoulModel):
 
 
 class Goal(ProsoulModel):
-    name = models.CharField(max_length=200, unique=True)
+    name = models.CharField(max_length=200, unique=False)
     # Relations
     attributes = models.ManyToManyField(Attribute)
     subgoals = models.ManyToManyField("Goal", blank=True)

--- a/django_prosoul/prosoul/templates/prosoul/editor_metric.html
+++ b/django_prosoul/prosoul/templates/prosoul/editor_metric.html
@@ -9,7 +9,7 @@
           {% for field in metric_form.state_fields %}
           {{ field }}
           {% endfor %}
-          {{ metric_form.old_attribute }}
+          {{ metric_form.old_attribute_id }}
           {{ metric_form.metric_id }}
           {{ metric_form.name.errors }}
           <div class="modal-header">

--- a/django_prosoul/prosoul/templates/prosoul/editor_scope.html
+++ b/django_prosoul/prosoul/templates/prosoul/editor_scope.html
@@ -3,11 +3,11 @@
   <tbody>
     <tr>
       <td>Goals</td>
-      <td>{{ goals_form.name|length }}</td>
+      <td>{{ goals_form.id|length }}</td>
     </tr>
     <tr>
       <td>Attributes</td>
-      <td>{{ attributes_form.name|length }}</td>
+      <td>{{ attributes_form.id|length }}</td>
     </tr>
     <tr>
       <td>Metrics</td>

--- a/django_prosoul/prosoul/views_editor.py
+++ b/django_prosoul/prosoul/views_editor.py
@@ -532,8 +532,9 @@ class AttributeView():
             form = forms_editor.AttributeForm(request.POST)
             if form.is_valid():
                 attribute_name = form.cleaned_data['attribute_name']
+                current_id = form.cleaned_data['current_id']
                 try:
-                    Attribute.objects.get(name=attribute_name).delete()
+                    Attribute.objects.get(id=current_id).delete()
                 except Attribute.DoesNotExist:
                     error = "Can't remove %s. Attribute does not exists." % attribute_name
                 send_context = build_forms_context(EditorState(form=form, attributes=[]))
@@ -609,8 +610,9 @@ class GoalView():
             form = forms_editor.GoalForm(request.POST)
             if form.is_valid():
                 goal_name = form.cleaned_data['goal_name']
+                current_id = form.cleaned_data['current_id']
                 try:
-                    Goal.objects.get(name=goal_name).delete()
+                    Goal.objects.get(id=current_id).delete()
                 except Goal.DoesNotExist:
                     error = "Can't remove %s. Goal does not exists." % goal_name
                 send_context = build_forms_context(EditorState(goals=[], form=form))


### PR DESCRIPTION
This is a feature needed to implement the clone of quality models.

The metrics names must be unique and also the quality models name.