### PR TITLE
[export] Remove name and description from alambic and ossmeter formats

### DIFF
--- a/django-prosoul/prosoul/prosoul_export.py
+++ b/django-prosoul/prosoul/prosoul_export.py
@@ -217,14 +217,12 @@ def gl2alambic(gl_models_json, model_name=None):
     def attribute2child(attribute):
         """ Convert an Alambic child to an attribute """
         al_attribute = {"active": "true", "type": "attribute",
-                        "description": attribute['description'],
-                        "mnemo": attribute['name'], "name": attribute['name'],
+                        "mnemo": attribute['name'],
                         "children": []}
 
         for metric in attribute['metrics']:
             al_metric = {"active": "true", "type": "metric",
-                         "description": metric['description'],
-                         "mnemo": metric['name'], "name": metric['name']}
+                         "mnemo": metric['name']}
             al_attribute['children'].append(al_metric)
 
         if 'subattributes' in attribute:
@@ -237,8 +235,6 @@ def gl2alambic(gl_models_json, model_name=None):
         """ In Alambic goals are first level attributes """
 
         goal_attribute = {"active": "true", "type": "attribute",
-                          "description": goal['description'],
-                          "name": goal['name'],
                           "mnemo": goal['name'], "children": []}
 
         for attribute in goal['attributes']:

--- a/django-prosoul/prosoul/tests.py
+++ b/django-prosoul/prosoul/tests.py
@@ -21,26 +21,28 @@ class ProsoulImportExport(TestCase):
 
     def off_test_import_export_alambic(self):
         """ Test the import/export process for quality models in alambic format """
-        # TODO is failing now
+        # TODO is failing now because assertDictEqual and keys ordering
         format_ = 'alambic'
         filepath = 'prosoul/data/alambic_quality_model.json'
         fmodel = open(filepath, "r")
         import_models_json = json.load(fmodel)
         fmodel.close()
+        models = import_models_json
         if format_ != "grimoirelab":
-            import_models_json = convert_to_grimoirelab(format_, import_models_json)
-        feed_models(import_models_json)
+            models = convert_to_grimoirelab(format_, import_models_json)
+        feed_models(models)
         compare_models(import_models_json, format_)
 
     def off_test_import_export_ossmeter(self):
         """ Test the import/export process for quality models in ossmeter format """
-        # TODO is failing now
+        # TODO is failing now because assertDictEqual and keys ordering
         format_ = 'ossmeter'
         filepath = 'prosoul/data/ossmeter_qm.json'
         fmodel = open(filepath, "r")
         import_models_json = json.load(fmodel)
         fmodel.close()
+        models = import_models_json
         if format_ != "grimoirelab":
-            import_models_json = convert_to_grimoirelab(format_, import_models_json)
-        feed_models(import_models_json)
+            models = convert_to_grimoirelab(format_, import_models_json)
+        feed_models(models)
         compare_models(import_models_json, format_)


### PR DESCRIPTION
These formats don't include this fields.

Also fix an error in alambic and ossmeter testing code.