### PR TITLE
[settings] Add 'wacke.ow2.org' to ALLOWED_HOSTS

### DIFF
--- a/django-prosoul/config_deployment.py
+++ b/django-prosoul/config_deployment.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+# -*- coding: utf-8 -*-
+#
+# Simple script to modify the Django settings to deploy:
+#   SECRET_KEY in a django project
+#   DEBUG = False
+#   ALLOWED_HOSTS = ['*']
+#
+# Copyright (C) 2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#   Valerio Cosentino <valcos@bitergia.com>
+#
+#
+
+import os
+
+settings_file = 'django_prosoul/settings.py'
+settings = None
+
+try:
+    allowed_hosts = os.environ['ALLOWED_HOSTS'].split(" ")
+except KeyError:
+    allowed_hosts = []
+
+with open(settings_file) as f:
+    settings = f.read()
+    settings = settings.replace("DEBUG = True", "DEBUG = False")
+    settings = settings.replace("ALLOWED_HOSTS = []", "ALLOWED_HOSTS = {}".format(str(allowed_hosts)))
+
+with open(settings_file, "w") as f:
+    f.write(settings)
+
+print("Django configured for deployment (secret, debug, allowed_hosts) in", settings_file)

--- a/django-prosoul/django_prosoul/settings.py
+++ b/django-prosoul/django_prosoul/settings.py
@@ -25,8 +25,7 @@ SECRET_KEY = 'u1*y8wy#a!tahh!lj0fk6n)22%0_g$y-8r5q_13gf_!i8veswq'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['prosoul', 'localhost', '172.17.0.1', '127.0.0.1']
-
+ALLOWED_HOSTS = []
 
 # Application definition
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,3 +17,5 @@ prosoul:
   image: acsdocker/prosoul
   ports:
    - "8000:8000"
+  environment:
+   - ALLOWED_HOSTS="prosoul localhost 172.17.0.1 127.0.0.1"

--- a/docker/stage
+++ b/docker/stage
@@ -3,7 +3,11 @@
 echo "Running Prosoul"
 
 git clone https://github.com/Bitergia/prosoul.git
-cd prosoul/django-prosoul/
+cd prosoul/
+# Fill the secret key, debug false and allow hosts
+./config_deployment.py
+
+cd django-prosoul/
 
 # Create the data models
 python3 manage.py makemigrations


### PR DESCRIPTION
This code extends the list of allowed hosts to include 'wacke.ow2.org'.