### PR TITLE
[base] Fix prosoul.svg missing image

### DIFF
--- a/django-prosoul/django_prosoul/templates/base.html
+++ b/django-prosoul/django_prosoul/templates/base.html
@@ -21,9 +21,7 @@
     </head>
     <body>
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <a href="/" class="navbar-brand">
-                <img src="/static/img/prosoul.svg" width="30" height="30" class="d-inline-block align-top" alt="">Prosoul
-            </a>
+            <a href="/" class="navbar-brand">Prosoul</a>
 
             <ul class="navbar-nav">
               <li class="nav-item">


### PR DESCRIPTION
This code removes the link to prosoul.svg, which was leading to 404 HTTP error,
since the image doesn't exist.