### PR TITLE
Improve "Editor" tab showing Metrics from the scava ES index

### DIFF
--- a/django-prosoul/prosoul/templates/prosoul/editor_metrics.html
+++ b/django-prosoul/prosoul/templates/prosoul/editor_metrics.html
@@ -8,8 +8,6 @@
         <span><i class="fa fa-plus"></i></span> Add<span class="sr-only"> metric data</span></button>
       <button type="submit" class="btn btn-primary btn-sm" id="edit-metric-btn"  data-toggle="modal" data-target="#addMetricModal">
         <span><i class="fa fa-pencil"></i> Edit<span class="sr-only"> metric data</span></button>
-      <button type="submit" class="btn btn-primary btn-sm" id="add-metric-data-btn"  data-toggle="modal" data-target="#addMetricDataModal">
-        <span><i class="fa fa-plus"></i> Data<span class="sr-only"> metric data</span></button>
     </div>
   </div>
 </div>

--- a/django-prosoul/prosoul/views_editor.py
+++ b/django-prosoul/prosoul/views_editor.py
@@ -398,6 +398,7 @@ class MetricView(LoginRequiredMixin, JustPostByEditorMixin, View):
             name = form.cleaned_data['metric_name']
             thresholds = form.cleaned_data['metric_thresholds']
             attribute_id = form.cleaned_data['attributes']
+            metric_data_id = form.cleaned_data['metrics_data']
 
             attribute_orm = Attribute.objects.get(id=attribute_id)
 
@@ -411,6 +412,9 @@ class MetricView(LoginRequiredMixin, JustPostByEditorMixin, View):
                 # Create a new metric
                 metric_orm = Metric(name=name, attribute=attribute_orm,
                                     thresholds=thresholds)
+            if metric_data_id:
+                metric_data_orm = MetricData.objects.get(id=metric_data_id)
+                metric_orm.data = metric_data_orm
 
             metric_orm.save()
 


### PR DESCRIPTION
This PR improves the behavior of the Editor tab:

- This PR add the fetch of the metrics from ElasicSearch (scava-metrics) and show them in the dropdown of Adding/Editing "Metrics" in Prosoul.
- This PR also solves a bug when adding a "Metric" the "Data" attribute is not saved.

