### PR TITLE
[views_editor] Prevent access metric index when doesn't exist

### DIFF
--- a/django-prosoul/prosoul/views_editor.py
+++ b/django-prosoul/prosoul/views_editor.py
@@ -718,6 +718,10 @@ def get_metrics_data():
 
     metrics_names = set()
 
+    if not es.indices.exists(index=METRICS_INDEX):
+        print("Index %s doesnt exist!" % METRICS_INDEX)
+        return
+
     page = es.search(
         index=METRICS_INDEX,
         scroll="1m",


### PR DESCRIPTION
This code prevents to query the index METRICS_INDEX when it doesn't exist. The error occurs when using Prosoul before the metrics are imported to ElasticSearch.

When testing https://github.com/crossminer/scava-deployment/pull/45, @MarcioMateus and @mhow2 reported this issue