### PR TITLE
[views_editor] Skip no metric data

### DIFF
--- a/django-prosoul/prosoul/views_editor.py
+++ b/django-prosoul/prosoul/views_editor.py
@@ -744,6 +744,12 @@ def get_metrics_data():
     while scroll_size > 0:
 
         for scava_metric in page['hits']['hits']:
+            # This check is needed to make sure that the METRICS_INDEX doesn't
+            # contain anything else beyond metric data.
+            if 'metric_name' not in scava_metric['_source']:
+                print("Item %s is not a metric, skipping it. Clean the index %s" % (str(scava_metric), METRICS_INDEX))
+                continue
+
             metrics_names.add(scava_metric['_source']['metric_name'])
 
         page = es.scroll(scroll_id=sid, scroll='1m')


### PR DESCRIPTION
This code is needed to skip items in METRICS_INDEX which are not metrics. This happens if the original index has been generated before scava-deployment/commit/36297246b1256a020bc62114747c67f20943abb4.