### PR TITLE
Remove validators in order to use the docker dependecies tags

### DIFF
--- a/django-prosoul/prosoul/forms.py
+++ b/django-prosoul/prosoul/forms.py
@@ -56,9 +56,7 @@ class VisualizationForm(forms.Form):
                                                                 widget=widget_select, choices=backends)
         # self.fields['quality_model'].widget = forms.Select()
         self.fields['es_url'] = forms.CharField(label='Elasticsearch URL', max_length=100, widget=widget)
-        self.fields['es_url'].validators = [URLValidator()]
         self.fields['kibana_url'] = forms.CharField(label='Kibana URL', max_length=100, widget=widget)
-        self.fields['kibana_url'].validators = [URLValidator()]
         self.fields['es_index'] = forms.CharField(label='Index with metrics data', max_length=100, widget=widget)
 
 


### PR DESCRIPTION
This PR fix the problem when putting "elasticsearch" and "kibiter" on the URLS.