### PR TITLE
[prosoul_assess] Delete score index per assessment execution

### DIFF
--- a/django-prosoul/prosoul/prosoul_assess.py
+++ b/django-prosoul/prosoul/prosoul_assess.py
@@ -387,6 +387,9 @@ def publish_assessment(es_url, es_index, assessment):
 
     es_conn = Elasticsearch([es_url], timeout=100, verify_certs=HTTPS_CHECK_CERT)
 
+    if es_conn.indices.exists(index=scores_index):
+        es_conn.indices.delete(index=scores_index)
+
     scores = []
 
     # Uploading info to the new ES

--- a/django-prosoul/setup.py
+++ b/django-prosoul/setup.py
@@ -70,8 +70,13 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'django>=2.0', 'matplotlib', 'grimoire-elk', 'sortinghat', 'kidash', 'djangorestframework', 'grimoirelab'
-                                                                                                    '-toolkit '
+        'django>=2.0',
+        'matplotlib',
+        'grimoire-elk',
+        'sortinghat',
+        'kidash',
+        'djangorestframework',
+        'grimoirelab-toolkit'
     ],
     python_requires='>=3.4'
 


### PR DESCRIPTION
This code allows to delete and recreate the score index each time the assessment is triggered. This change is needed to allow the user to assess as many as qm he wants given two time intervals. Furthermore a minor change wrt the dependencies in the setup.py has been done to have them listed one per line.