### PR TITLE
[views] Fix method signature `download_csv`

### DIFF
--- a/django-prosoul/prosoul/prosoul_assess.py
+++ b/django-prosoul/prosoul/prosoul_assess.py
@@ -25,7 +25,6 @@
 
 import argparse
 import csv
-import datetime
 import json
 import logging
 import operator

--- a/django-prosoul/prosoul/views.py
+++ b/django-prosoul/prosoul/views.py
@@ -238,7 +238,7 @@ class Assessment(LoginRequiredMixin, View):
             return shortcuts.render(request, 'prosoul/assessment.html', context)
 
 
-def download_csv(request, project):
+def download_csv(request, project=None):
     if project:
         file_path = ASSESSMENT_CSV_DIR_PATH + "assessment_csv_" + project + ".csv"
     else:


### PR DESCRIPTION
After the addition of the new feature to download single assessment reports, the global one was not working anymore due to a missing parameter in the method `download_csv`. Furthermore this PR fixes also a flake error due to an unused import.