### PR TITLE
[prosoul] Support for top_hit aggregation

### DIFF
--- a/django-prosoul/prosoul/forms_editor.py
+++ b/django-prosoul/prosoul/forms_editor.py
@@ -272,7 +272,8 @@ class MetricForm(ProsoulEditorForm):
                              ('min', 'Min'),
                              ('avg', 'Average'),
                              ('median', 'Median'),
-                             ('sum', 'Sum')]
+                             ('sum', 'Sum'),
+                             ('last', 'Last')]
         self.fields['calculation_type'] = forms.ChoiceField(label='Calculation Type', required=True,
                                                             widget=self.widget, choices=calculation_types)
 

--- a/django-prosoul/prosoul/prosoul_assess.py
+++ b/django-prosoul/prosoul/prosoul_assess.py
@@ -246,6 +246,29 @@ def compute_metric_per_project_ossmeter(es_url, es_index, metric_field, metric_d
             }
           }
         }"""
+    elif calculation_type == 'last':
+        es_query += """
+            "aggs": {
+                "2": {
+                  "top_hits": {
+                    "docvalue_fields": [
+                      "metric_es_value"
+                    ],
+                    "_source": "metric_es_value",
+                    "size": 1,
+                    "sort": [
+                      {
+                        "datetime": {
+                          "order": "desc"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+        }
+        }"""
     else:
         es_query += """
             "aggs": {
@@ -266,6 +289,8 @@ def compute_metric_per_project_ossmeter(es_url, es_index, metric_field, metric_d
     for pb in project_buckets:
         if calculation_type == 'median':
             metric_value = pb["2"]["values"]['50.0']
+        elif calculation_type == "last":
+            metric_value = pb["2"]["hits"]["hits"][0]["fields"]["metric_es_value"][0]
         else:
             metric_value = pb["2"]["value"]
         project_metrics.append({"project": pb['key'], "metric": metric_value})


### PR DESCRIPTION
This code allows to select the last value of a metric, by leveraging on the top_hit aggregation provided
by ElasticSearch.