### PR TITLE
Fix bug when removing quality models

### DIFF
--- a/django-prosoul/prosoul/views_editor.py
+++ b/django-prosoul/prosoul/views_editor.py
@@ -322,7 +322,7 @@ class QualityModelView(JustPostByEditorMixin, UserPassesTestMixin, LoginRequired
         if form.is_valid():
             qmodel_name = form.cleaned_data['qmodel_name']
             try:
-                QualityModel.objects.get(name=qmodel_name, created_by=request.user).delete()
+                QualityModel.objects.get(name=qmodel_name).delete()
             except QualityModel.DoesNotExist:
                 errors = "Can't delete not found quality model %s" % qmodel_name
         else:


### PR DESCRIPTION
As the name is a UID, it isn't necessary to add the user.

This PR fixes #153 