### PR TITLE
[prosoul-views_editor] Allow float thresholds

### DIFF
--- a/django-prosoul/prosoul/views_editor.py
+++ b/django-prosoul/prosoul/views_editor.py
@@ -410,9 +410,9 @@ def check_thresholds(thresholds):
     else:
         for x in thresholds_value:
             try:
-                int(x)
+                float(x)
             except ValueError:
-                error = "Thresholds must be integers"
+                error = "Thresholds must be float"
                 thresholds_ok = False
                 break
     return thresholds_ok, error


### PR DESCRIPTION
This code allows to define float thresholds for prosoul metrics.