### PR TITLE
[prosoul_assess] Increase size of aggregated results

### DIFF
--- a/django-prosoul/prosoul/prosoul_assess.py
+++ b/django-prosoul/prosoul/prosoul_assess.py
@@ -236,7 +236,8 @@ def compute_metric_per_project_ossmeter(es_url, es_index, metric_field, metric_d
       "aggs": {
         "3": {
           "terms": {
-            "field": "project"
+            "field": "project",
+            "size": 5000
           },
     """ % (metric_field, metric_name, from_date, to_date)
 


### PR DESCRIPTION
This code allows to return more than the default number of projects (10) when assessing their quality attributes. Currently this number is now set to 5000.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>