### PR TITLE
Add "no_value" and visual notification when the metric hasn't value

### DIFF
--- a/django-prosoul/prosoul/templates/prosoul/assessment_config.html
+++ b/django-prosoul/prosoul/templates/prosoul/assessment_config.html
@@ -134,18 +134,24 @@
                   .attr("x", function(d) { return d.children || d._children ? -20 : 20; })
                   .attr("dy", function(d) { return d.children || d._children ? "-0.5em" : ".35em" })
                   .attr("text-anchor", function(d) { return d.children || d.children ? "end" : "start"; })
-                  .attr("fill", function(d) { return d.active == "true" ? "black" : "gray";})
                   .text(function(d) {
                     if(d[project]) {
                       return d.name + " (" + d.cal_type + ") - " + d[project].score + " (" + d[project].raw_value + ")"
                     } else {
                         if(d.children){
-                            med = analyzeAssess(d, project)
-                            return d.name + " - " + med
+                            [med, n_children] = analyzeAssess(d, project)
+                            if (n_children !== d.children.length){
+                                return d.name + " - " + med + " ( ! )"
+                            }else{
+                                return d.name + " - " + med
+                            }
                         } else {
-                            return d.name + " - " + 0
+                            return d.name + " - no_value"
                         }
                     }
+                  })
+                  .attr("fill", function(d) {
+                    return (this.innerHTML.includes("( ! )") || this.innerHTML.includes("- no_value")) ? "red" : "gray";
                   })
                   .style("fill-opacity", 1e-6);
 
@@ -208,17 +214,28 @@
         }
 
         function analyzeAssess(node, project) {
-            value = 0
+            let value = 0
+            let n_children = 0
             node.children.forEach(function(e) {
                 if (e.children) {
-                    value += analyzeAssess(e, project)
+                    [new_value, new_n_children] = analyzeAssess(e, project)
+                    if(new_value !== "no_value"){
+                        value += new_value;
+                        n_children++
+                    }
                 }else{
                     if (e[project]){
                         value += e[project].score
+                        n_children++
                     }
                 }
             });
-            return Math.round(value/node.children.length * 100) / 100
+            //return Math.round(value/node.children.length * 100) / 100
+            if(n_children > 0){
+                return [Math.round(value/n_children * 100) / 100, n_children]
+            } else {
+                return ["no_value", 0]
+            }
         }
 
     </script>


### PR DESCRIPTION
This commit adds a visual feature to the assessment dendrogram,
when a metric has not value, now it shows a "no_value" string and
a red color. Moreover, the parent will not take into account this
"no_value" metric and will show the string "( ! )" in order to
notice the user that the assessment is not complete and the
text will be in red color as well.

Examples:

![Screenshot from 2019-11-13 15-13-23](https://user-images.githubusercontent.com/9249232/68771379-36702880-0628-11ea-891e-0382a121c4d4.png)
![Screenshot from 2019-11-13 15-13-12](https://user-images.githubusercontent.com/9249232/68771380-36702880-0628-11ea-9a65-9c7e07b62596.png)


Directly related to #186 