### PR TITLE
[prosoul_assess] Store empty values to ES

### DIFF
--- a/django-prosoul/prosoul/prosoul_assess.py
+++ b/django-prosoul/prosoul/prosoul_assess.py
@@ -357,7 +357,7 @@ def assess_attribute(es_url, es_index, attribute, backend_metrics_data, from_dat
     logging.debug('Doing the assessment for attribute: %s', attribute.name)
     # Collect all metrics that are included in the models
     metrics_with_data = []
-    atribute_assessment = {}  # Includes the assessment for each metric per project
+    attribute_assessment = {}  # Includes the assessment for each non-empty metric per project
 
     for metric in attribute.metrics.all():
         # We need the metric values and the metric indicators
@@ -370,7 +370,7 @@ def assess_attribute(es_url, es_index, attribute, backend_metrics_data, from_dat
     logging.debug("Metrics to be included: %s (%s attribute)", metrics_with_data, attribute.name)
 
     for metric in metrics_with_data:
-        atribute_assessment[metric.data.implementation] = {}
+        attribute_assessment[metric.data.implementation] = {}
         metric_value = compute_metric_per_project(es_url, es_index, metric.data, backend_metrics_data, from_date, to_date)
         if metric_value:
             for project_metric in metric_value:
@@ -392,18 +392,20 @@ def assess_attribute(es_url, es_index, attribute, backend_metrics_data, from_dat
                     threshold = score - 1 if score else 0
                     logging.debug("Score %s for %s: %i (%s)", project_metric['project'],
                                   metric.data.implementation, score, THRESHOLDS[threshold])
-                if pname not in atribute_assessment[metric.data.implementation]:
-                    atribute_assessment[metric.data.implementation][pname] = {}
-                atribute_assessment[metric.data.implementation][pname]['score'] = score
-                atribute_assessment[metric.data.implementation][pname]['raw_value'] = project_metric['metric']
-                atribute_assessment[metric.data.implementation]['cal_type'] = metric.data.calculation_type
+
+                if pname not in attribute_assessment[metric.data.implementation]:
+                    attribute_assessment[metric.data.implementation][pname] = {}
+
+                attribute_assessment[metric.data.implementation][pname]['score'] = score
+                attribute_assessment[metric.data.implementation][pname]['raw_value'] = project_metric['metric']
+                attribute_assessment[metric.data.implementation]['cal_type'] = metric.data.calculation_type
         else:
             msg = "Metric {} has not value for time range {} - {}".format(metric,
                                                                           from_date.strftime('%Y-%m-%d'),
                                                                           to_date.strftime('%Y-%m-%d'))
             logging.debug(msg)
 
-    return atribute_assessment
+    return attribute_assessment
 
 
 def goals2projects(assessment):

--- a/django-prosoul/prosoul/prosoul_assess.py
+++ b/django-prosoul/prosoul/prosoul_assess.py
@@ -168,7 +168,7 @@ def compute_metric_per_projects_grimoirelab(es_url, es_index, metric_field, metr
 
     logging.debug(json.dumps(json.loads(es_query), indent=True))
 
-    res = requests.post(es_url + "/" + es_index + "/_search", data=es_query, verify=HTTPS_CHECK_CERT, headers=HEADERS_JSON)
+    res = requests.get(es_url + "/" + es_index + "/_search", data=es_query, verify=HTTPS_CHECK_CERT, headers=HEADERS_JSON)
     res.raise_for_status()
 
     project_buckets = res.json()["aggregations"]["3"]["buckets"]
@@ -290,7 +290,7 @@ def compute_metric_per_project_ossmeter(es_url, es_index, metric_field, metric_d
           }
         }""" % calculation_type
 
-    res = requests.post(es_url + "/" + es_index + "/_search", data=es_query, verify=HTTPS_CHECK_CERT, headers=HEADERS_JSON)
+    res = requests.get(es_url + "/" + es_index + "/_search", data=es_query, verify=HTTPS_CHECK_CERT, headers=HEADERS_JSON)
     res.raise_for_status()
 
     project_buckets = res.json()["aggregations"]["3"]["buckets"]


### PR DESCRIPTION
This PR allows to store the empty values obtained from the assessment of the quality models in ES. After calculating the assessment dict, all projects available in ES are retrieved and used to calculate the diff of the assessment dict. It mimics the structure of the assessment dict and it includes only the empty metrics. This operation is applied for quarters and over all the time span of the assessment.

The empty data is stored in ES, in two different indexes. One contains the empty data for quarters, while the other one the empty data for all the time span. Indexes with data and with empty data share the same alias, thus allowing to perform searches on both type of data in a transparent way.

This PR provides also some minor fixes and modifies the logic of the `goals2projects` function, which is now accepting the assessment dict and its diff.