### PR TITLE
add license headers and copyright information

### DIFF
--- a/django-prosoul/config_deployment.py
+++ b/django-prosoul/config_deployment.py
@@ -2,7 +2,7 @@
 
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/django-prosoul/django_prosoul/create_admin_superuser.py
+++ b/django-prosoul/django_prosoul/create_admin_superuser.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 #
 # Authors:
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
 #
 #
 

--- a/django-prosoul/prosoul/admin.py
+++ b/django-prosoul/prosoul/admin.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#
+#
+
 from django.contrib import admin
 from . import models
 

--- a/django-prosoul/prosoul/apps.py
+++ b/django-prosoul/prosoul/apps.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#
+#
+
 from django.apps import AppConfig
 
 

--- a/django-prosoul/prosoul/data.py
+++ b/django-prosoul/prosoul/data.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#
+#
+
 import json
 import logging
 import os.path

--- a/django-prosoul/prosoul/data_editor.py
+++ b/django-prosoul/prosoul/data_editor.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#
+#
+
 from prosoul.models import Attribute, QualityModel, Goal, Metric, MetricData
 
 

--- a/django-prosoul/prosoul/forms.py
+++ b/django-prosoul/prosoul/forms.py
@@ -1,3 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
+#
+
 import os
 
 from django import forms

--- a/django-prosoul/prosoul/forms_editor.py
+++ b/django-prosoul/prosoul/forms_editor.py
@@ -1,3 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
+#
+
 import functools
 
 from time import time

--- a/django-prosoul/prosoul/metrics_import.py
+++ b/django-prosoul/prosoul/metrics_import.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Load CROSSMINER metrics definition in Prosoul
-#
-# Copyright (C) 2017 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +14,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#
 #
 
 import argparse

--- a/django-prosoul/prosoul/models.py
+++ b/django-prosoul/prosoul/models.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
+#
+
 from django.db import models
 from django.contrib.auth.models import User
 from django.core.validators import validate_comma_separated_integer_list

--- a/django-prosoul/prosoul/prosoul_assess.py
+++ b/django-prosoul/prosoul/prosoul_assess.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Assess a Software Project based on Quality Models
-#
-# Copyright (C) Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +14,13 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
 #
 
 import argparse

--- a/django-prosoul/prosoul/prosoul_export.py
+++ b/django-prosoul/prosoul/prosoul_export.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Export a Metrics Model to a file
-#
-# Copyright (C) 2017 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +14,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
 #
 
 import argparse

--- a/django-prosoul/prosoul/prosoul_import.py
+++ b/django-prosoul/prosoul/prosoul_import.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Import Metrics Models in Prosoul
-#
-# Copyright (C) 2017 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +14,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
 #
 
 import argparse

--- a/django-prosoul/prosoul/prosoul_metrics.py
+++ b/django-prosoul/prosoul/prosoul_metrics.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# ProSoul Metrics Manager Tool
-#
-# Copyright (C) Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,8 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Alvaro del Castillo San Felix <acs@bitergia.com>

--- a/django-prosoul/prosoul/prosoul_utils.py
+++ b/django-prosoul/prosoul/prosoul_utils.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#
+#
+
 # Supported backends for providing the data for metrics in the quality models
 BACKEND_METRICS_DATA = ['scava-metrics', 'grimoirelab', 'ossmeter']
 

--- a/django-prosoul/prosoul/prosoul_vis.py
+++ b/django-prosoul/prosoul/prosoul_vis.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Create a Kibana Dashboard to show a Quality Model
-#
-# Copyright (C) Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +14,13 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
 #
 
 import argparse

--- a/django-prosoul/prosoul/rest.py
+++ b/django-prosoul/prosoul/rest.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#
+#
+
 # Serializers define the API representation.
 
 from django.contrib.auth.models import User

--- a/django-prosoul/prosoul/tests.py
+++ b/django-prosoul/prosoul/tests.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#
+#
+
 # import json
 
 # from django.test import TestCase

--- a/django-prosoul/prosoul/urls.py
+++ b/django-prosoul/prosoul/urls.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
+#
+
 from django.conf.urls import include, url
 from django.views.generic import RedirectView
 

--- a/django-prosoul/prosoul/views.py
+++ b/django-prosoul/prosoul/views.py
@@ -1,3 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
+#
+
 import json
 import os
 

--- a/django-prosoul/prosoul/views_editor.py
+++ b/django-prosoul/prosoul/views_editor.py
@@ -1,3 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Valerio Cosentino <valcos@bitergia.com>
+#   David Moreno <dmoreno@bitergia.com>
+#
+#
+
 import functools
 import json
 

--- a/django-prosoul/setup.py
+++ b/django-prosoul/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This PR has two commits. One is for adding the info for files that don't have it and one for updating the info.

Fixes #13 

I know we have a discussion pending in the grimoirelab repo about the license headers updation, but I updated the authors and years too in this PR. 

@acs @valeriocos 
Can you review this when you are free?

I can squash the two commits if you want. :slightly_smiling_face: 
Please let me know if I have to add or delete anything.