### PR TITLE
[travis] Upgrade setuptools and pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 sudo: false
 
 before_install:
+  - pip install --upgrade setuptools
+  - pip install --upgrade pip
   - pip install flake8
   - pip install coveralls
   - cd django-prosoul && pip install -r requirements.txt && cd ..


### PR DESCRIPTION
This PR updates the travis.yml with the setuptools and pip as it was needed to avoid the failure of the CI tests.
Ref: https://github.com/chaoss/grimoirelab-perceval/pull/643

Fixes #208 